### PR TITLE
vendor: versioning: allow editing build date format from device tree

### DIFF
--- a/config/version.mk
+++ b/config/version.mk
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Versioning System
-BUILD_DATE := $(shell date +%Y%m%d)
+BUILD_DATE ?= $(shell date +%Y%m%d)
 TARGET_PRODUCT_SHORT := $(subst aosip_,,$(AOSIP_BUILDTYPE))
 
 AOSIP_BUILDTYPE ?= DerpFest-Beta


### PR DESCRIPTION
 *Adding "BUILD_DATE := xxxxxxx"(any format for date) in aosip_$device.mk will change the build date for build.
 *If not adding, fall-back to default i.e., %Y%m%d

Signed-off-by: marshmello61 <ultramayur123@gmail.com>