### PR TITLE
add NO_GAPPS_BUILD to make it easier to build a no-gapps version

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -123,7 +123,11 @@ PRODUCT_PACKAGES += \
     themed_bootanimation
 
 # GApps
+ifeq ($(NO_GAPPS_BUILD),true)
+#include vendor/gapps/config.mk
+else
 include vendor/gapps/config.mk
+endif
 
 # Pixel Style
 include vendor/pixelstyle/config.mk


### PR DESCRIPTION
I added a variable to compile the version without gapps and only need to pass in a NO_GAPPS_BUILD as true