### PR TITLE
changelog: properly split each of manifest entry

### DIFF
--- a/tools/changelog.sh
+++ b/tools/changelog.sh
@@ -49,6 +49,7 @@ PROJECTPATHS=$(grep "<project" "${MANIFEST}" | sed -n 's/.*path="\([^"]\+\)".*/\
 
 # Add repos in local manifest for DT changelog
 for lManifest in $TOP/.repo/local_manifests/*; do
+	PROJECTPATHS+=" "
 	PROJECTPATHS+=$(grep "<project" "${lManifest}" | sed -n 's/.*path="\([^"]\+\)".*/\1/p')
 done
 


### PR DESCRIPTION
Loop through words is simpler than using arrays, but it'll be a chaos
when you forget to put the IFS when adding a new entry.

This should fix an issues such as :
   ./vendor/aosip/tools/changelog.sh: line 75: cd: /home/nullxception/android/vendor/pixelstyledevice/xiaomi/raphael: No such file or directory

Where the IFS is missing from the two entries.

Fixes: 83cb572 ("changelog: Also generate for repos in local manifests")
Signed-off-by: Nauval Rizky <enuma.alrizky@gmail.com>