### PR TITLE
Add flag to common_full_phone.mk

### DIFF
--- a/config/common_full_phone.mk
+++ b/config/common_full_phone.mk
@@ -1,6 +1,9 @@
 # Inherit common stuff
 $(call inherit-product, vendor/aosip/config/common.mk)
 
+#Telephony
+IS_PHONE := true
+
 # World APN list
 PRODUCT_PACKAGES += \
     apns-conf.xml


### PR DESCRIPTION
Makes it more friendly to build, as a lot of people forget to add the flag in device tree